### PR TITLE
srcDir is not doing what you think its doing, removing it fixes it.

### DIFF
--- a/github_api.nimble
+++ b/github_api.nimble
@@ -5,7 +5,6 @@ author        = "Chris Watson"
 description   = "Connector for the GitHub API v3"
 license       = "WTFPL"
 
-srcDir        = "github_api"
 skipDirs      = @["test"]
 
 # Dependencies


### PR DESCRIPTION
srcDir moves "root" of your package, but you don't need to.

fixes this error: 
```
C:\Users\me\Dropbox\p\nimwatch\pkgs\github_api> nimble tasks -n
   Warning: File inside package 'github_api' is outside of permitted namespace, should be named 'github_api.nim' but was named 'client.nim' instead. This will be an error in the future.
      Hint: Rename this file to 'github_api.nim', move it into a 'github_api\' subdirectory, or prevent its installation by adding `skipFiles = @["client.nim"]` to the .nimble file. See https://github.com/nim-lang/nimble#libraries for more info.
```